### PR TITLE
Database configuration

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -46,6 +46,9 @@ argv = optimist
   .options('id',
     describe  : 'Set the location of the open id file'
   )
+  .options('database',
+    describe  : 'JSON object for database config'
+  )
   .options('test',
     boolean   : true
     describe  : 'Set server to work with the rspec integration tests'

--- a/lib/defaultargs.coffee
+++ b/lib/defaultargs.coffee
@@ -16,6 +16,11 @@ module.exports = (argv) ->
   argv.url or= 'http://localhost' + (':' + argv.port) unless argv.port is 80
   argv.id or= path.join(argv.status, 'persona.identity')
 
+  if typeof(argv.database) is 'string'
+    argv.database = JSON.parse(argv.database)
+  argv.database or= {}
+  argv.database.type or= './page'
+
   #resolve all relative paths
   argv.root = path.resolve(argv.root)
   argv.data = path.resolve(argv.data)

--- a/lib/leveldb.js
+++ b/lib/leveldb.js
@@ -1,13 +1,13 @@
 var path = require('path')
 
-  , levelup = require('levelup')
+  , level = require('level')
   , es = require('event-stream')
 
   , fsPage = require('./page')
   , synopsis = require('../client/lib/synopsis')
 
 module.exports = function (opts) {
-  var db = levelup(path.join(opts.db, 'pagedb'), {encoding: 'json'})
+  var db = level(path.join(opts.data, 'leveldb'), {encoding: 'json'})
     , classicPageGet = fsPage(opts).get
 
   function put (file, page, cb) {

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -35,12 +35,6 @@ wiki = require '../client/lib/wiki'
 pluginsFactory = require './plugins'
 Persona = require './persona_auth'
 
-# pageFactory can be easily replaced here by requiring your own page handler
-# factory, which gets called with the argv object, and then has get and put
-# methods that accept the same arguments and callbacks.
-# Currently './page' and './leveldb' are provided.
-pageFactory = require './page'
-
 render = (page) ->
   return f.h1(
     f.a({href: '/', style: 'text-decoration: none'},
@@ -92,9 +86,8 @@ module.exports = exports = (argv) ->
         log "Allready fired", error
     next()
 
-  # Tell pagehandler where to find data, and default data.
-  app.pagehandler = pagehandler = pageFactory(argv)
-
+  # Require the database adapter and initialize it with options.
+  app.pagehandler = pagehandler = require(argv.database.type)(argv)
 
   #### Setting up Authentication ####
   # The owner of a server is simply the open id url that the wiki


### PR DESCRIPTION
To go with the great work on #12 by @christiansmith

This allows you to specify your database config any way you can any other config option.

```
wiki --database='{"type": "./redis"}'

wiki_database='{"type": "./leveldb"}' wiki

echo '{"database": {"type": "./redis", "port": 123, "host": "foo"}}' > config.json && wiki

echo '{"database": {"port": 123, "host": "foo"}}' > leveldb.json && wiki --config=leveldb.json
```

The only option that should be required for a database to work is "type", which is how the database is to be required. It is the only property with a default value, which is "./page".
