### PR TITLE
Add npm install step for developing Wiki

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -40,6 +40,7 @@ This package consists of client and server code as well as a number of sample pl
 
     $ git clone https://github.com/WardCunningham/wiki.git
     $ cd wiki
+    $ npm install
     $ grunt build
     $ npm start
 


### PR DESCRIPTION
Without it, grunt won't be installed locally and will fail to build.
