### PR TITLE
Use Verdana in preference to Helvetica (which is just Arial on Windows!)

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -17,7 +17,7 @@ body {
   overflow: hidden;
   padding: 0;
   margin: 0;
-  font-family: "Helvetica Neue", helvetica, Verdana, Arial, Sans;
+  font-family: "Helvetica Neue", Verdana, helvetica, Arial, Sans;
   line-height: 1.3;
   color: #333333; }
 


### PR DESCRIPTION
Changing the font order. So using a Windows browsers, which are unlikely to have "Helvetica Neue", we don't just end up with Arial. 

For any without access to a Windows browser, in the image below the current css is on the left, and the modified on the right. ![capture](https://f.cloud.github.com/assets/1552489/1130951/a61771ce-1bb1-11e3-943e-484af407d483.PNG)

_On Windows Helvetica is not Helvetica: it's Arial, even if you have Helvetica installed. See [Helvetial](http://meyerweb.com/eric/thoughts/2013/03/12/helvetial/) for a fuller view of the problem._
