### PR TITLE
Not saving to localStore for unauthenticated users on claimed site

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -227,6 +227,11 @@ module.exports = exports = (argv) ->
         'Site owned by ' + owner.substr(0, owner.indexOf('@'))
       else
         ''
+      loginStatus: if owner
+        if req.isAuthenticated()
+          'logout'
+        else 'login'
+      else 'claim'
       loginBtnTxt: if owner
         if req.isAuthenticated()
           'Sign out'
@@ -262,6 +267,11 @@ module.exports = exports = (argv) ->
           'Site owned by ' + owner.substr(0, owner.indexOf('@'))
         else
           ''
+        loginStatus: if owner
+          if req.isAuthenticated()
+            'logout'
+          else 'login'
+        else 'claim'
         loginBtnTxt: if owner
           if req.isAuthenticated()
             'Sign out'

--- a/views/static.html
+++ b/views/static.html
@@ -24,7 +24,7 @@
       <div class='page' id={{page}} {{origin}} {{generated}}>{{{story}}}</div>
       {{/pages}}
     </section>
-    <footer>
+    <footer class={{loginStatus}}>
       
       <div id='site-owner' class='footer-item'>{{ownedBy}}</div>
 


### PR DESCRIPTION
Whoops....

Spotted while looking at static site generation...

Adding back in loginStatus as class for the footer and server code to populate the value...

No excuse, but was also researching what was need to support more complex security models at the time. Sorry. 
