### PR TITLE
require synopsis from wiki-client package

### DIFF
--- a/lib/leveldb.js
+++ b/lib/leveldb.js
@@ -4,7 +4,7 @@ var path = require('path')
   , es = require('event-stream')
 
   , fsPage = require('./page')
-  , synopsis = require('../client/lib/synopsis')
+  , synopsis = require('wiki-client/lib/synopsis')
 
 module.exports = function (opts) {
   var db = level(path.join(opts.data, 'leveldb'), {encoding: 'json'})

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1,6 +1,6 @@
 var mongodb  = require('mongoskin')
   , fsPage   = require('./page')
-  , synopsis = require('../client/lib/synopsis');
+  , synopsis = require('wiki-client/lib/synopsis');
 
 module.exports = function (opts) {
   var config         = opts.database

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,6 +1,6 @@
 var redis = require('redis')
   , fsPage = require('./page')
-  , synopsis = require('../client/lib/synopsis')
+  , synopsis = require('wiki-client/lib/synopsis')
 
 
 module.exports = function (opts) {


### PR DESCRIPTION
In the latest npm package, 0.0.5, the require for synopsis fails as it is now part of the wiki-client package rather than being in client/lib.

Found while testing an update to the OpenShift Quickstart, to add support for MongoDB.
