### PR TITLE
First pass at improving Persona error handling

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -340,3 +340,6 @@ textarea {
   opacity: 0.6;
   border-color: #eef2fe;
 }
+
+/* font size of jquery ui dialog */
+.ui-dialog{font-size:13px;}

--- a/views/static.html
+++ b/views/static.html
@@ -5,7 +5,7 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'>
     <meta content='width=device-width, height=device-height, initial-scale=1.0, user-scalable=no' name='viewport'>
     <link id='favicon' href='/favicon.png' rel='icon' type='image/png'>
-    <link href='/style.css' rel='stylesheet' type='text/css'>
+
     <link href='/style/persona-buttons.css' rel='stylesheet' type='text/css'>
     <!-- <link href='/theme/granite.css' rel='stylesheet' type='text/css'> -->
     <script src='/js/jquery-1.9.1.min.js' type='text/javascript'></script>
@@ -15,6 +15,7 @@
     <script src='/js/modernizr.custom.63710.js' type='text/javascript'></script>
     <script src='/js/underscore-min.js' type='text/javascript'></script>
     <script src="https://login.persona.org/include.js"></script>
+    <link href='/style.css' rel='stylesheet' type='text/css'>
     <script src='/client.js' type='text/javascript'></script>
     <script>Modernizr.load([{test: Modernizr.cors, nope: '/js/jquery.ie.cors.js'}]);</script>
   </head>


### PR DESCRIPTION
Rather than using `fail()`, which causes an AJAX error in the client, we return the failure reason back to the client to handle.

While this pull request traps the behaviour described in #36, the route cause still needs catching earlier. Need to trap when the site is accessed using an address other than that used in the Person audience (either using an alias, or a different protocol).

Pull request WardCunningham/wiki-client#4 is also needed, to provide the client portions of this update.
