### PR TITLE
Specify/restrict host that bouncy will use

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -102,8 +102,7 @@ else if argv.test
 # If f/farm is set call../lib/farm.coffee with argv object, else call
 # ../lib/server.coffee with argv object.
 else if config.farm
-  console.log('Wiki starting in Farm mode, navigate to a specific server to sart it.')
+  console.log('Wiki starting in Farm mode, navigate to a specific server to start it.')
   farm(config)
 else
   server(config)
-

--- a/lib/farm.coffee
+++ b/lib/farm.coffee
@@ -31,13 +31,13 @@ module.exports = exports = (argv) ->
       incHost = req.headers.host
     else
       return
-    
+
     # If the host starts with "www." treat it the same as if it didn't
     if incHost[0..3] is "www."
       incHost = incHost[4..]
     # if we already have a port for this host, forward the request to it.
     if hosts[incHost]
-      bounce(hosts[incHost])
+      bounce(argv.host, hosts[incHost])
     else
       hosts[incHost] = nextport()
       # Create a new options object, copy over the options used to start the
@@ -56,5 +56,5 @@ module.exports = exports = (argv) ->
       local = server(newargv)
       runningServers.push(local)
       local.once "listening", ->
-        bounce(hosts[incHost])
-  ).listen(argv.port)
+        bounce(argv.host, hosts[incHost])
+  ).listen(argv.port, argv.host)


### PR DESCRIPTION
This changes is needed to support farms on OpenShift - specifying the host that bouncy will listen on, and bounce to.

Part of the fix for WardCunningham/Smallest-Federated-Wiki#413, there is an accompanying change  paul90/wiki-openshift-quickstart#6 that adds configuration for starting up Farm Mode.
