### PR TITLE
ignore forks when figuring date for sitemap

### DIFF
--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -149,6 +149,11 @@ module.exports = exports = (argv) ->
       queue.push({file, page, cb})
       serial(queue.shift()) unless working
 
+  editDate = (journal) ->
+    for action in (journal || []) by -1
+      return action.date if action.date and action.type != 'fork'
+    undefined
+
   itself.pages = (cb) ->
     fs.readdir argv.db, (e, files) ->
       return cb(e) if e
@@ -163,7 +168,7 @@ module.exports = exports = (argv) ->
           cb null, {
             slug     : file
             title    : page.title
-            date     : page.journal and page.journal.length > 0 and page.journal.pop().date
+            date     : editDate(page.journal)
             synopsis : synopsis(page)
           }
 


### PR DESCRIPTION
Fix for issue https://github.com/fedwiki/wiki-node/issues/20

Now Recent Changes will show pages with exactly the same last edit without spacing.
(This use to happen only when rsync'ing pages between sites.)

![image](https://cloud.githubusercontent.com/assets/12127/5430723/17e340de-83cc-11e4-8201-5c6c2d2788be.png)
