### PR TITLE
pass app to plugins to add routes

### DIFF
--- a/lib/security.coffee
+++ b/lib/security.coffee
@@ -27,6 +27,8 @@ module.exports = exports = (log, loga, argv) ->
 
   owner = ''
 
+  admin = argv.admin
+
   # save the location of the identity file
   idFile = argv.id
 
@@ -68,6 +70,10 @@ module.exports = exports = (log, loga, argv) ->
       return true
     else
       return false
+
+  # Wiki server admin
+  security.isAdmin = ->
+    return false
 
   security.defineRoutes = (app, cors, updateOwner) ->
     # default security does not have any routes

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -560,11 +560,11 @@ module.exports = exports = (argv) ->
     console.log "owner: " + owner
     app.emit 'owner-set'
 
-  app.on 'running-serv', (serv) ->
+  app.on 'running-serv', (server) ->
     ### Plugins ###
     # Should replace most WebSocketServers below.
     plugins = pluginsFactory(argv)
-    plugins.startServers({server: serv, argv})
+    plugins.startServers({server, argv, app})
     ### Sitemap ###
     # create sitemap at start-up
     sitemaphandler.createSitemap(pagehandler)

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -242,9 +242,11 @@ module.exports = exports = (argv) ->
   # Can also be handled by the client, but it also sets up
   # the login status, and related footer html, which the client
   # relies on to know if it is logged in or not.
-  app.get ///^((/[a-zA-Z0-9:.-]+/[a-z0-9-]+(_rev\d+)?)+)/?$///, (req, res) ->
+  app.get ///^((/[a-zA-Z0-9:.-]+/[a-z0-9-]+(_rev\d+)?)+)/?$///, (req, res, next) ->
     urlPages = (i for i in req.params[0].split('/') by 2)[1..]
     urlLocs = (j for j in req.params[0].split('/')[1..] by 2)
+    if urlLocs[0] is 'plugin'
+      return next()
     user = securityhandler.getUser(req)
     info = {
       pages: []

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -566,7 +566,7 @@ module.exports = exports = (argv) ->
     ### Plugins ###
     # Should replace most WebSocketServers below.
     plugins = pluginsFactory(argv)
-    plugins.startServers({server, argv, app})
+    plugins.startServers({argv, app})
     ### Sitemap ###
     # create sitemap at start-up
     sitemaphandler.createSitemap(pagehandler)

--- a/package.json
+++ b/package.json
@@ -61,9 +61,6 @@
     "grunt-mocha-test": "~0.12",
     "grunt-git-authors": "~3"
   },
-  "optionalDependencies": {
-    "ws": "*"
-  },
   "engines": {
     "node": ">=0.10"
   },


### PR DESCRIPTION
Caution: I've yet to successfully build this module.

This pull request adds app to the parameters passed to a server-side plugin. This allows the plugin to add routes for restful service to the client-side plugin. Until now we have used websockets for this communication.

The Shell plugin provides an example of this in use. [github](https://github.com/WardCunningham/wiki-plugin-shell/blob/master/server/server.coffee)

![image](https://cloud.githubusercontent.com/assets/12127/12383172/b4807c66-bd57-11e5-95e8-a1971365cb44.png)

As mentioned above, I'm having trouble building this module such that it can be npm-linked into a current install of wiki. I've successfully hand patched this functionality into wiki's installed version but a build from source gives this error on startup. I'll need some help diagnosing this.
```
node index.js -p 3020

 Error: Cannot find module 'wiki-security-persona'
  at Function.Module._resolveFilename (module.js:336:15)
  at Function.Module._load (module.js:286:25)
  at Module.require (module.js:365:17)
  at require (module.js:384:17)
  at module.exports.exports (/Users/ward/FedWiki/wiki-server/lib/server.js:133:43)
  at Object.<anonymous> (/Users/ward/FedWiki/wiki/cli.coffee:133:9)
  at Object.<anonymous> (/Users/ward/FedWiki/wiki/cli.coffee:1:1)
```