### PR TITLE
ignore sitemap pages with null date in xml conversion

### DIFF
--- a/lib/sitemap.coffee
+++ b/lib/sitemap.coffee
@@ -92,11 +92,12 @@ module.exports = exports = (argv) ->
   xmlSitemapSave = (sitemap, cb) ->
     xmlmap = []
     _.each sitemap, (page) ->
-      return unless page.date
       result = {}
       result["loc"] = argv.url + "/" + page.slug + ".html"
-      date = new Date(page.date)
-      result["lastmod"] = date.toISOString().substring(0,10)
+      if page.date?
+        date = new Date(page.date)
+        if !(isNaN(date.valueOf()))
+          result["lastmod"] = date.toISOString().substring(0,10)
       xmlmap.push result
     xmlmap = {'urlset': {"$": {"xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9"},'url': xmlmap}}
     builder = new xml2js.Builder()

--- a/lib/sitemap.coffee
+++ b/lib/sitemap.coffee
@@ -92,6 +92,7 @@ module.exports = exports = (argv) ->
   xmlSitemapSave = (sitemap, cb) ->
     xmlmap = []
     _.each sitemap, (page) ->
+      return unless page.date
       result = {}
       result["loc"] = argv.url + "/" + page.slug + ".html"
       date = new Date(page.date)


### PR DESCRIPTION
This guard protects against pages with no date, probably with no journal at all. I have such pages in my test site and get this error on startup.

```
 RangeError: Invalid time value
  at Date.toISOString (native)
  at /Users/ward/test-restful-plugins/node_modules/wiki/node_modules/wiki-server/lib/sitemap.js:121:32
  at arrayEach (/Users/ward/test-restful-plugins/node_modules/wiki/node_modules/wiki-server/node_modules/lodash/index.js:1289:13)
  at Function.<anonymous> (/Users/ward/test-restful-plugins/node_modules/wiki/node_modules/wiki-server/node_modules/lodash/index.js:3345:13)
  at xmlSitemapSave (/Users/ward/test-restful-plugins/node_modules/wiki/node_modules/wiki-server/lib/sitemap.js:115:7)
  at serial (/Users/ward/test-restful-plugins/node_modules/wiki/node_modules/wiki-server/lib/sitemap.js:169:14)
  at /Users/ward/test-restful-plugins/node_modules/wiki/node_modules/wiki-server/lib/sitemap.js:209:16
  at doNTCallback0 (node.js:407:9)
  at process._tickCallback (node.js:336:13)

```