### PR TITLE
clear timeout when we remove sitemap from memory

### DIFF
--- a/lib/sitemap.coffee
+++ b/lib/sitemap.coffee
@@ -141,6 +141,7 @@ module.exports = exports = (argv) ->
     clearsitemap = ->
       console.log "removing sitemap from memory"
       sitemap = []
+      clearTimeout(sitemapTimeoutHandler)
     sitemapTimeoutHandler = setTimeout clearsitemap, sitemapTimeoutMs
     working = false
     @emit 'finished'


### PR DESCRIPTION
The timeout was not getting cleared, so it kept firing periodically to empty the in memory sitemap, even if it had already been emptied.