### PR TITLE
proper title served for .html version

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -247,9 +247,10 @@ module.exports = exports = (argv) ->
     urlLocs = (j for j in req.params[0].split('/')[1..] by 2)
     if urlLocs[0] is 'plugin'
       return next()
+    title = urlPages[..].pop().replace(/-+/g,' ')
     user = securityhandler.getUser(req)
     info = {
-      title: 'Federated Wiki'
+      title
       pages: []
       authenticated: if user
         true
@@ -283,7 +284,7 @@ module.exports = exports = (argv) ->
       if e then return res.e e
       if status is 404
         return res.status(status).send(page)
-      page.title ||= slug
+      page.title ||= slug.replace(/-+/g,' ')
       page.story ||= []
       user = securityhandler.getUser(req)
 

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -249,6 +249,7 @@ module.exports = exports = (argv) ->
       return next()
     user = securityhandler.getUser(req)
     info = {
+      title: 'Federated Wiki'
       pages: []
       authenticated: if user
         true

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -58,7 +58,7 @@ render = (page) ->
   f.div({class: "header"}, f.h1(
     f.a({href: '/', style: 'text-decoration: none'},
       f.img({height: '32px', src: '/favicon.png'})) +
-      ' ' + page.title)) + '\n' +
+      ' ' + (page.title))) + '\n' +
     f.div {class: "story"},
       page.story.map((story) ->
         if story.type is 'paragraph'
@@ -274,18 +274,22 @@ module.exports = exports = (argv) ->
     res.render('static.html', info)
 
   app.get ///([a-z0-9-]+)\.html$///, (req, res, next) ->
-    file = req.params[0]
-    log(file)
-    if file is 'runtests'
+    slug = req.params[0]
+    log(slug)
+    if slug is 'runtests'
       return next()
-    pagehandler.get file, (e, page, status) ->
+    pagehandler.get slug, (e, page, status) ->
       if e then return res.e e
       if status is 404
         return res.status(status).send(page)
+      page.title ||= slug
+      page.story ||= []
       user = securityhandler.getUser(req)
+
       info = {
+        title: page.title
         pages: [
-          page: file
+          page: slug
           generated: """data-server-generated=true"""
           story: render(page)
         ]


### PR DESCRIPTION
This commit adds the proper page title, or slug if no title, to the substitutable template parameters available to wiki-client's static.html.