### PR TITLE
Some cookie updates

### DIFF
--- a/lib/defaultargs.coffee
+++ b/lib/defaultargs.coffee
@@ -30,6 +30,7 @@ module.exports = (argv) ->
   argv.id or= path.join(argv.status, 'owner.json')
   argv.uploadLimit or= '5mb'
   argv.cookieSecret or= require('crypto').randomBytes(64).toString('hex')
+  argv.session_duration or= 7
   argv.neighbors or= ''
   argv.debug or= false
 

--- a/lib/defaultargs.coffee
+++ b/lib/defaultargs.coffee
@@ -30,6 +30,7 @@ module.exports = (argv) ->
   argv.id or= path.join(argv.status, 'owner.json')
   argv.uploadLimit or= '5mb'
   argv.cookieSecret or= require('crypto').randomBytes(64).toString('hex')
+  argv.secure_cookie or= false
   argv.session_duration or= 7
   argv.neighbors or= ''
   argv.debug or= false

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -190,9 +190,9 @@ module.exports = exports = (argv) ->
     requestKey: 'session',
     secret: argv.cookieSecret,
     # make the session a week long
-    duration: 7 * 24 * 60 * 60 * 1000,
+    duration: argv.session_duration * 24 * 60 * 60 * 1000,
     # add 12 hours to session if less than 12 hours to expiry
-    activeDuration: 12 * 60 * 60 * 1000,
+    activeDuration: 24 * 60 * 60 * 1000,
     cookie: cookieValue
     }))
 

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -185,11 +185,13 @@ module.exports = exports = (argv) ->
     httpOnly: true
   }
   cookieValue['domain'] = argv.wiki_domain if argv.wiki_domain
+  # use secureProxy as TLS is terminated in outside the node process
+  cookieValue['secureProxy'] = true if argv.secure_cookie
   app.use(sessions({
     cookieName: 'wikiSession',
     requestKey: 'session',
     secret: argv.cookieSecret,
-    # make the session a week long
+    # make the session session_duration days long
     duration: argv.session_duration * 24 * 60 * 60 * 1000,
     # add 12 hours to session if less than 12 hours to expiry
     activeDuration: 24 * 60 * 60 * 1000,


### PR DESCRIPTION
Add two new parameters:

* `session_duration` that allows a different session duration to be set (the default is 7 days), and
* `secure_cookie` that will make the cookie *secure*, so it will only be served over https connection.