### PR TITLE
Proxy request for site owner

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -44,6 +44,7 @@ methodOverride = require 'method-override'
 sessions = require 'client-sessions'
 bodyParser = require 'body-parser'
 errorHandler = require 'errorhandler'
+request = require 'request'
 
 
 # Local files
@@ -471,6 +472,18 @@ module.exports = exports = (argv) ->
 
   securityhandler.defineRoutes app, cors, updateOwner
 
+  ##### Proxy routes #####
+
+  app.get '/proxy/*', authorized, (req, res) ->
+    pathParts = req.path.split('/')
+    remoteHost = pathParts[2]
+    pathParts.splice(0,3)
+    remoteResource = pathParts.join('/')
+    requestURL = 'http://' + remoteHost + '/' + remoteResource
+    if requestURL.endsWith('.json') or requestURL.endsWith('.png')
+      request(requestURL).pipe(res)
+    else
+      res.status(400).end()
 
 
   ##### Put routes #####

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -480,8 +480,22 @@ module.exports = exports = (argv) ->
     pathParts.splice(0,3)
     remoteResource = pathParts.join('/')
     requestURL = 'http://' + remoteHost + '/' + remoteResource
+    console.log("PROXY Request: ", requestURL)
     if requestURL.endsWith('.json') or requestURL.endsWith('.png')
-      request(requestURL).pipe(res)
+      requestOptions = {
+        host: remoteHost
+        port: 80
+        path: remoteResource
+      }
+      try
+        request
+          .get(requestURL, requestOptions)
+          .on('error', (err) ->
+            console.log("ERROR: Request ", requestURL, err))
+          .pipe(res)
+      catch error
+        console.log "PROXY Error", error
+        res.status(500).end()
     else
       res.status(400).end()
 

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     }
   ],
   "dependencies": {
-    "JSONStream": "^1.2.1",
+    "JSONStream": "^1.3.0",
     "async": "^2.1.4",
     "body-parser": "^1.9.0",
     "client-sessions": "0.7",
-    "coffee-script": "^1.11.1",
+    "coffee-script": "^1.12.2",
     "coffee-trace": "*",
     "config-chain": "^1.1.11",
     "cookie-parser": "^1.3.3",
@@ -40,6 +40,7 @@
     "morgan": "^1.3.1",
     "optimist": "*",
     "qs": "^6.3.0",
+    "request": "^2.79.0",
     "sanitize-caja": "^0.1.4",
     "serve-static": "^1.6.3",
     "write-file-atomic": "^1.2.0",
@@ -55,12 +56,12 @@
     "grunt-git-authors": "^3.2.0",
     "grunt-mocha-test": "^0.13.2",
     "grunt-nsp": "*",
-    "grunt-retire": "^1.0.3",
+    "grunt-retire": "^1.0.6",
     "mocha": "^2.5.3",
-    "should": "^11.1.1",
+    "should": "^11.1.2",
     "sinon": "^1.17.6",
     "supertest": "^2.0.1",
-    "wiki-client": "^0.8.1",
+    "wiki-client": "^0.8.2",
     "wiki-plugin-activity": "*"
   },
   "engines": {


### PR DESCRIPTION
Part of the work exploring making wiki-client protocol agnostic. When we server the origin over `https` browers restrict access to non-secure resources, so we **must** fetch any remote resources over a secure connection as well.

Thus PR adds a `/proxy` route that fetches resources on behalf of the client that would not otherwise be available. We limit access to this route to the site owner.