### PR TITLE
defeat plugin annotation for normal pages

### DIFF
--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -63,7 +63,7 @@ module.exports = exports = (argv) ->
     unless page?
       fs.exists(loc, (exists) =>
         if exists
-          load_parse(loc, cb)
+          load_parse(loc, cb, {plugin: undefined})
         else
           defloc = path.join(argv.root, 'default-data', 'pages', file)
           fs.exists(defloc, (exists) ->


### PR DESCRIPTION
We remove the green halo from about pages that have been forked into normal page space.

![screen shot 2017-05-22 at 9 17 34 am](https://cloud.githubusercontent.com/assets/12127/26318337/aa55b238-3ecf-11e7-857d-b7edb8d6578e.png)


Future pull requests will handle client-side adjustments at the moment of fork and ultimately a mechanism for deleting unwanted or accidental forks of about pages.