### PR TITLE
redirect / to home assets when present

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -646,10 +646,11 @@ module.exports = exports = (argv) ->
   # Traditional request to / redirects to index :)
   app.get '/', (req, res) ->
     home = path.join argv.assets, 'home', 'index.html'
-    if fs.existsSync(home)
-      res.redirect("/assets/home/index.html")
-    else
-      res.redirect(index)
+    fs.stat home, (err, stats) ->
+      if err || !stats.isFile()
+        res.redirect(index)
+      else
+        res.redirect("/assets/home/index.html")
 
   ##### Delete Routes #####
 

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -645,7 +645,11 @@ module.exports = exports = (argv) ->
 
   # Traditional request to / redirects to index :)
   app.get '/', (req, res) ->
-    res.redirect(index)
+    home = path.join argv.assets, 'home', 'index.html'
+    if fs.existsSync(home)
+      res.redirect("/assets/home/index.html")
+    else
+      res.redirect(index)
 
   ##### Delete Routes #####
 


### PR DESCRIPTION
We aspire to offer a safe and familiar welcome.

http://ward.asia.wiki.org/safe-and-familiar-welcome.html

With this pull request we enable site owners acting individually to customise the welcome page for their sites using normal html and css without privileged access to the server or cooperation with any other user. With the Assets plugin a site owner can upload arbitrary files to any subdirectory of assets. We reserve the `home` subdirectory for the purpose of defining specialized welcomes.

I've designed a specialized welcome for the `start.fed.wiki` site. Click `index.html` here where I explain my process to see the welcome displayed.

http://start.fed.wiki/making-the-welcome-page.html

With this wiki-server change installed my custom design will become the default welcome for the site. I've tested this locally by uploading the same html and css files to localhost.

![image](https://user-images.githubusercontent.com/12127/35200381-58f389d4-fec2-11e7-8fc6-7b72456ca642.png)
