### PR TITLE
lock event-stream to 3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "config-chain": "^1.1.11",
     "cookie-parser": "^1.3.3",
     "errorhandler": "^1.5.0",
-    "event-stream": "^3.3.4",
+    "event-stream": "3.3.4",
     "express": "^4.15.4",
     "express-hbs": "^1.0.4",
     "flates": "0.0.5",


### PR DESCRIPTION
GHSA-mh6f-8j2x-4483
critical severity
Vulnerable versions: > 3.3.4
Patched version: No fix

The NPM package flatmap-stream is considered malicious. A malicious actor added this package as a dependency to the NPM event-stream package in versions 3.3.6 and later. Users of event-stream are encouraged to downgrade to the last non-malicious version, 3.3.4.

Users of flatmap-stream are encouraged to remove the dependency entirely.