### PR TITLE
Remove assumption about where wiki-client gets installed on disk

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -166,7 +166,8 @@ module.exports = exports = (argv) ->
   # including hbs to use handlebars/mustache templates
   # saved with a .html extension, and no layout.
 
-  app.set('views', path.join(__dirname, '..', '..', 'wiki-client', '/views'))
+  app.set('views',
+    path.join(require.resolve('wiki-client/package.json'), '..', 'views'))
   app.set('view engine', 'html')
   app.engine('html', hbs.express4())
   app.set('view options', layout: false)


### PR DESCRIPTION
Use require.resolve() to find the location on disk.

~Depends on https://github.com/fedwiki/wiki-client/pull/245~

Motivation for the change:

Wiki previously assumed the locations of wiki-client and wiki-server
within node_modules. Glitch.com uses pnpm to install node modules. It
organizes the filesystem differently than wiki-server expected.

This change lets node's resolution tell us where the wiki-client is
installed.

I think this is a better solution than #147 