### PR TITLE
guard against nulls in page json

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -58,6 +58,7 @@ render = (page) ->
       ' ' + (page.title))) + '\n' +
     f.div {class: "story"},
       page.story.map((story) ->
+        return '' unless story
         if story.type is 'paragraph'
           f.div {class: "item paragraph"}, f.p(resolveClient.resolveLinks(story.text))
         else if story.type is 'image'


### PR DESCRIPTION
We can't guarantee that we won't encounter corrupted page json but we can ignore them.

```
/wiki-server/lib/server.coffee:86
      if (story.type === 'paragraph') {
                ^
TypeError: Cannot read property 'type' of null
```

I've found these errors by digging through server logs when seeing unexpected server restarts.