### PR TITLE
Add backlinks and serve default favicon.

### DIFF
--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -319,7 +319,7 @@ module.exports = exports = (argv) ->
           if pageLinksMap.size > 0
             pageLinks = Object.fromEntries(pageLinksMap)
           else
-            pageLinks = {}
+            pageLinks = undefined
         
           cb null, {
             slug     : file

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -294,7 +294,8 @@ module.exports = exports = (argv) ->
         linkRe = /\[\[([^\]]+)\]\]/g
         match = undefined
         while (match = linkRe.exec(currentItem.text)) != null
-          collaborativeLinks.add asSlug match[1]
+          if not collaborativeLinks.has(asSlug(match[1]))
+            collaborativeLinks.set(asSlug(match[1]), currentItem.id)
       catch err
         console.log "METADATA *** #{wikiName} Error extracting links from #{currentIndex} of #{JSON.stringify(array)}", err.message
       collaborativeLinks
@@ -311,14 +312,14 @@ module.exports = exports = (argv) ->
             return cb() # Ignore errors in the pagehandler get.
 
           try
-            pageLinksSet = page.story.reduce( extractPageLinks, new Set())
+            pageLinksMap = page.story.reduce( extractPageLinks, new Map())
           catch err
             console.log "METADATA *** #{wikiName} reduce to extract links on #{slug} failed", err.message
           #
-          if pageLinksSet.size > 0
-            pageLinks = Array.from(pageLinksSet)
+          if pageLinksMap.size > 0
+            pageLinks = Object.fromEntries(pageLinksMap)
           else
-            pageLinks = []
+            pageLinks = {}
         
           cb null, {
             slug     : file

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -402,11 +402,15 @@ module.exports = exports = (argv) ->
       )
 
   ###### Favicon Routes ######
-  # If favLoc doesn't exist send 404 and let the client
-  # deal with it.
+  # If favLoc doesn't exist send the default favicon.
   favLoc = path.join(argv.status, 'favicon.png')
+  defaultFavLoc = path.join(argv.root, 'default-data', 'status', 'favicon.png')
   app.get '/favicon.png', cors, (req,res) ->
-    res.sendFile(favLoc)
+    fs.exists favLoc, (exists) ->
+      if exists
+        res.sendFile(favLoc)
+      else
+        res.sendFile(defaultFavLoc)
 
   authorized = (req, res, next) ->
     if securityhandler.isAuthorized(req)

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -197,7 +197,9 @@ module.exports = exports = (argv) ->
     httpOnly: true
     sameSite: 'lax'
   }
-  cookieValue['domain'] = argv.wiki_domain if argv.wiki_domain
+  if argv.wiki_domain
+    if !argv.wiki_domain.endsWith('localhost')
+      cookieValue['domain'] = argv.wiki_domain
   # use secureProxy as TLS is terminated in outside the node process
   if argv.secure_cookie
     cookieName = 'wikiTlsSession'

--- a/lib/sitemap.coffee
+++ b/lib/sitemap.coffee
@@ -70,7 +70,7 @@ module.exports = exports = (argv) ->
     if pageLinksMap.size > 0
       pageLinks = Object.fromEntries(pageLinksMap)
     else
-      pageLinks = []
+      pageLinks = undefined
 
     entry = {
       'slug': file

--- a/lib/sitemap.coffee
+++ b/lib/sitemap.coffee
@@ -56,18 +56,19 @@ module.exports = exports = (argv) ->
         linkRe = /\[\[([^\]]+)\]\]/g
         match = undefined
         while (match = linkRe.exec(currentItem.text)) != null
-          collaborativeLinks.add asSlug match[1]
+          if not collaborativeLinks.has(asSlug(match[1]))
+            collaborativeLinks.set(asSlug(match[1]), currentItem.id)
       catch err
         console.log "METADATA *** #{wikiName} Error extracting links from #{currentIndex} of #{JSON.stringify(array)}", err.message
       collaborativeLinks
 
     try
-      pageLinksSet = page.story.reduce( extractPageLinks, new Set())
+      pageLinksMap = page.story.reduce( extractPageLinks, new Map())
     catch err
       console.log "METADATA *** #{wikiName} reduce to extract links on #{slug} failed", err.message
     #
-    if pageLinksSet.size > 0
-      pageLinks = Array.from(pageLinksSet)
+    if pageLinksMap.size > 0
+      pageLinks = Object.fromEntries(pageLinksMap)
     else
       pageLinks = []
 


### PR DESCRIPTION
This PR is part of some work carried out during December 2020.

* Details of collaborative links on page are add to sitemap. Use in the client to show backlinks on a page.
* A small change in cookie serving when used with localhost and its subdomains.
* Where a site does not yet have a favicon, use the default favicon. This resolves an issue that Ward spotted with newly created wiki not working correctly. This issue was also show during the 30 Dec 2020 hangout, by @andrewshell

The changes in this PR are intended for use along with the changes in fedwiki/wiki-client#270