### PR TITLE
fix html route

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -306,7 +306,7 @@ module.exports = exports = (argv) ->
       info.pages.push(pageDiv)
     res.render('static.html', info)
 
-  app.get ///([a-z0-9-]+)\.html$///, (req, res, next) ->
+  app.get ///^\/([a-z0-9-]+)\.html$///, (req, res, next) ->
     slug = req.params[0]
     log(slug)
     if slug is 'runtests'


### PR DESCRIPTION
only look for `.html` routes at the root.
Allows fetching html from other places.