### PR TITLE
add cors to plugin path

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -226,7 +226,7 @@ module.exports = exports = (argv) ->
     plugins.map (plugin) ->
       pluginName = plugin.slice(12, -7)
       pluginPath = '/plugins/' + pluginName
-      app.use(pluginPath, express.static(path.join(argv.packageDir, plugin), staticPathOptions))
+      app.use(pluginPath, cors, express.static(path.join(argv.packageDir, plugin), staticPathOptions))
 
   # Add static routes to the security client.
   if argv.security != './security'


### PR DESCRIPTION
This is being added to bring bring plugin paths inline with how asset paths are handled.

This allows frame plugin pages, and scripts, to be distributed as plugins and for them to use locally provided ES Modules.