### PR TITLE
add parameter, and default, for the location of commons

### DIFF
--- a/lib/defaultargs.coffee
+++ b/lib/defaultargs.coffee
@@ -28,6 +28,7 @@ module.exports = (argv) ->
   argv.status or= path.join(argv.data, 'status')
   argv.assets or= path.join(argv.data, 'assets')
   argv.recycler or= path.join(argv.data, 'recycle')
+  argv.commons or= path.join(arvg.data, 'commons')
   argv.url or= 'http://localhost' + (if argv.port is 80 then '' else ':' + argv.port)
   argv.id or= path.join(argv.status, 'owner.json')
   argv.uploadLimit or= '5mb'
@@ -64,6 +65,7 @@ module.exports = (argv) ->
   argv.status = path.resolve(argv.status)
   argv.assets = path.resolve(argv.assets)
   argv.recycler = path.resolve(argv.recycler)
+  argv.commons = path.resolve(argv.commons)
   argv.id = path.resolve(argv.id)
 
   if /node_modules/.test(argv.data)


### PR DESCRIPTION
Add parameter for location of the commons directory, using in the [updated image plugin](https://github.com/fedwiki/wiki-plugin-image/pull/6).

Commons directory must be on the same drive as the asset directories for the hard links used by the image plugin to work.