### PR TITLE
Fixing corrupted site-index

### DIFF
--- a/lib/search.coffee
+++ b/lib/search.coffee
@@ -172,7 +172,7 @@ module.exports = exports = (argv) ->
             # really need to extract text from the markdown, but for now just remove link brackets, urls...
             pageText += ' ' + currentItem.text.replace /\[{2}|\[(?:[\S]+)|\]{1,2}|\\n/g, ' '
           when 'html'
-            pageText += ' ' + currentItem.text.replace /<[^>]*>/g, ''
+            pageText += ' ' + currentItem.text.replace /<[^\>]*>?/g, ''
           else
             if currentItem.text?
               for line in currentItem.text.split /\r\n?|\n/

--- a/lib/search.coffee
+++ b/lib/search.coffee
@@ -44,53 +44,37 @@ module.exports = exports = (argv) ->
         fs.close fd, (err) ->
           cb(err)
 
-  searchPageUpdate = (slug, page, origStory, cb) ->
+  searchPageUpdate = (slug, page, cb) ->
     # to update we have to remove the page first, and then readd it
     timeLabel = "SITE INDEX update #{slug} - #{wikiName}"
     console.time timeLabel
+    
     try
-      origText = origStory.reduce( extractPageText, '')
+      pageText = page.story.reduce( extractPageText, '')
     catch err
-      console.log "SITE INDEX *** #{wikiName} reduce to extract the original text on #{slug} failed", err.message
-      origText = ""
-    try
-      siteIndex.remove {
+      console.log "SITE INDEX *** #{wikiName} reduce to extract the text on #{slug} failed", err.message
+      pageText = ""
+    if siteIndex.has slug
+      siteIndex.replace {
         'id': slug
         'title': page.title
-        'content': origText
+        'content': pageText
       }
-    catch err
-      # swallow error, if the page was not in index
-      console.log "SITE INDEX *** removing #{slug} from index failed", err unless err.message.includes('not in the index')
-
-    try
-      newText = page.story.reduce( extractPageText, '')
-    catch err
-      console.log "SITE INDEX *** #{wikiName} reduce to extract the new text on #{slug} failed", err.message
-      newText = ""
-    siteIndex.add {
-      'id': slug
-      'title': page.title
-      'content': newText
-    }
+    else
+      siteIndex.add {
+        'id': slug
+        'title': page.title
+        'content': pageText
+      }
     console.timeEnd timeLabel
     cb()
 
-  searchPageRemove = (slug, title, origStory, cb) ->
+  searchPageRemove = (slug, cb) ->
     # remove page from index
     timeLabel = "SITE INDEX page remove #{slug} - #{wikiName}"
     console.time timeLabel
     try
-      origText = origStory.reduce( extractPageText, '')
-    catch err
-      console.log "SITE INDEX *** #{wikiName} reduce to extract the text for removing #{slug} failed", err.message
-      origText = ""
-    try
-      siteIndex.remove {
-        'id': slug
-        'title': title
-        'content': origText
-      }
+      siteIndex.discard slug 
     catch err
       # swallow error, if the page was not in index
       console.log "removing #{slug} from index #{wikiName} failed", err unless err.message.includes('not in the index')
@@ -140,14 +124,14 @@ module.exports = exports = (argv) ->
       switch item.action
         when "update"
           itself.start()
-          searchPageUpdate(item.slug, item.page, item.origStory, (e) ->
+          searchPageUpdate(item.slug, item.page, (e) ->
             process.nextTick( ->
               serial(queue.shift())
             )
           )
         when "remove"
           itself.start()
-          searchPageRemove(item.slug, item.title, item.origStory, (e) ->
+          searchPageRemove(item.slug, item.title, (e) ->
             process.nextTick( ->
               serial(queue.shift())
             )
@@ -247,9 +231,9 @@ module.exports = exports = (argv) ->
         process.nextTick ( ->
           serial(queue.shift()))
       
-  itself.removePage = (slug, title, origStory) ->
+  itself.removePage = (slug) ->
     action = "remove"
-    queue.push({action, slug, title, origStory})
+    queue.push({action, slug })
     if Array.isArray(siteIndex) and !working
       itself.start()
       searchRestore (e) ->
@@ -258,9 +242,9 @@ module.exports = exports = (argv) ->
     else
       serial(queue.shift()) unless working
 
-  itself.update = (slug, page, origStory) ->
+  itself.update = (slug, page) ->
     action = "update"
-    queue.push({action, slug, page, origStory})
+    queue.push({action, slug, page})
     if Array.isArray(siteIndex) and !working
       itself.start()
       searchRestore( (e) ->

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -610,12 +610,11 @@ module.exports = exports = (argv) ->
     actionCB = (e, page, status) ->
       #if e then return res.e e
       if status is 404
-        res.status(status).send(page)
+        # res.status(status).send(page)
+        return res.e page,status
       # Using Coffee-Scripts implicit returns we assign page.story to the
       # result of a list comprehension by way of a switch expression.
       try
-        # save the original page, so we can remove it from the index.
-        origStory = Object.assign([], page.story) or []
         page.story = switch action.type
           when 'move'
             action.order.map (id) ->
@@ -667,7 +666,7 @@ module.exports = exports = (argv) ->
       sitemaphandler.update(req.params[0], page)
 
       # update site index
-      searchhandler.update(req.params[0], page, origStory)
+      searchhandler.update(req.params[0], page)
 
     # log action
 
@@ -721,7 +720,6 @@ module.exports = exports = (argv) ->
     # we need the original page text to remove it from the index, so get the original text before deleting it
     pagehandler.get pageFile, (e, page, status) ->
       title = page.title
-      origStory = Object.assign([], page.story) or []
       pagehandler.delete pageFile, (err) ->
         if err
           res.status(500).send(err)
@@ -729,7 +727,7 @@ module.exports = exports = (argv) ->
           sitemaphandler.removePage pageFile
           res.status(200).send('')
           # update site index
-          searchhandler.removePage(req.params[0], title, origStory)
+          searchhandler.removePage(req.params[0])
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "glob": "^7.1.4",
         "lodash": "^4.17.19",
         "method-override": "^2.3.10",
-        "minisearch": "^5.0.0",
+        "minisearch": "^6.0.0",
         "mkdirp": "^0.5.5",
         "morgan": "^1.9.1",
         "node-fetch": "^2.6.1",
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -73,7 +73,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -245,9 +245,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/body-parser/node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -264,9 +264,9 @@
       }
     },
     "node_modules/body-parser/node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -483,13 +483,13 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -508,7 +508,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -601,9 +601,9 @@
       "optional": true
     },
     "node_modules/express-hbs/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -662,9 +662,9 @@
       "optional": true
     },
     "node_modules/express-hbs/node_modules/js-beautify": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.6.tgz",
-      "integrity": "sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
+      "integrity": "sha512-5SOX1KXPFKx+5f6ZrPsIPEY7NwKeQz47n3jm2i+XeHx9MoRsfQenlOP13FQhWvg8JRS0+XLO6XYUQ2GX+q+T9A==",
       "optional": true,
       "dependencies": {
         "config-chain": "^1.1.13",
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/express-hbs/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -704,9 +704,12 @@
       }
     },
     "node_modules/express-hbs/node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/express-hbs/node_modules/neo-async": {
       "version": "2.6.2",
@@ -795,9 +798,9 @@
       }
     },
     "node_modules/express-hbs/node_modules/uglify-js": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.1.tgz",
-      "integrity": "sha512-+juFBsLLw7AqMaqJ0GFvlsGZwdQfI2ooKQB39PSBgMnMakcFosi9O8jCwE+2/2nMNcc0z63r9mwjoDG8zr+q0Q==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -1101,9 +1104,9 @@
       }
     },
     "node_modules/express/node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1145,9 +1148,9 @@
       }
     },
     "node_modules/express/node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -1679,9 +1682,9 @@
       }
     },
     "node_modules/grunt-contrib-watch/node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1956,9 +1959,9 @@
       "dev": true
     },
     "node_modules/grunt-retire/node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -2039,6 +2042,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
       "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
       "dev": true,
       "dependencies": {
         "debuglog": "^1.0.1",
@@ -2722,9 +2726,9 @@
       }
     },
     "node_modules/grunt/node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -3326,9 +3330,9 @@
       }
     },
     "node_modules/minisearch": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-5.0.0.tgz",
-      "integrity": "sha512-VEwBhl8aFtc2UG2XmP7a4XaZxVfNhe7GvB2W/ZRGbLL3P3LbBhkoOezBWsMqG8Mr5VonqXAMRWth79XXKja1bQ=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.0.0.tgz",
+      "integrity": "sha512-N7yUgtH5T9iQfdmzI8Dnke8TK+grccrWUsdiwvalGv04hJggOUI/EpWIEQj3v8t7XSi/kSfQ7GdLAS540+GxpQ=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -3342,9 +3346,12 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mocha": {
       "version": "9.2.2",
@@ -3429,9 +3436,9 @@
       }
     },
     "node_modules/mocha/node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4353,9 +4360,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+      "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4466,9 +4473,9 @@
       }
     },
     "node_modules/request/node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/request/node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -4696,9 +4703,9 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/request/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
+      "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==",
       "engines": {
         "node": ">=6"
       }
@@ -4922,9 +4929,9 @@
       "dev": true
     },
     "node_modules/supertest/node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "node_modules/supertest/node_modules/core-util-is": {
@@ -5086,9 +5093,9 @@
       "dev": true
     },
     "node_modules/supertest/node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5188,9 +5195,9 @@
       "dev": true
     },
     "node_modules/wiki-client": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/wiki-client/-/wiki-client-0.24.0.tgz",
-      "integrity": "sha512-1lpoCiZznOWwPbVZ4JjTMPerXGRVpRCssr9l1TorEmTWyZ2ov+0xCdZzzR3KgPXMu/YwEPxebKvGUZjlTCTYkA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/wiki-client/-/wiki-client-0.24.2.tgz",
+      "integrity": "sha512-b2vB9w6beCMg1qcNB/qtNPd8xD8K7aNqFc61vMSsEXozsKnIjMo3pQRga5aPeupSQSFQGBgVZTLhzigjVtTuIQ==",
       "dev": true,
       "dependencies": {
         "async": "^3.2.1",
@@ -5257,10 +5264,13 @@
       "dev": true
     },
     "node_modules/wiki-plugin-activity/node_modules/camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/wiki-plugin-activity/node_modules/dom-walk": {
       "version": "0.1.2",
@@ -5458,9 +5468,9 @@
       }
     },
     "body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "requires": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -5470,7 +5480,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -5595,9 +5605,9 @@
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "object-inspect": {
-          "version": "1.12.2",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
         },
         "on-finished": {
           "version": "2.4.1",
@@ -5608,9 +5618,9 @@
           }
         },
         "qs": {
-          "version": "6.10.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
           "requires": {
             "side-channel": "^1.0.4"
           }
@@ -5771,13 +5781,13 @@
       }
     },
     "express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -5796,7 +5806,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -6010,9 +6020,9 @@
           "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
         },
         "object-inspect": {
-          "version": "1.12.2",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
         },
         "on-finished": {
           "version": "2.4.1",
@@ -6042,9 +6052,9 @@
           }
         },
         "qs": {
-          "version": "6.10.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
           "requires": {
             "side-channel": "^1.0.4"
           }
@@ -6221,9 +6231,9 @@
           "optional": true
         },
         "glob": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -6268,9 +6278,9 @@
           "optional": true
         },
         "js-beautify": {
-          "version": "1.14.6",
-          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.6.tgz",
-          "integrity": "sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==",
+          "version": "1.14.7",
+          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
+          "integrity": "sha512-5SOX1KXPFKx+5f6ZrPsIPEY7NwKeQz47n3jm2i+XeHx9MoRsfQenlOP13FQhWvg8JRS0+XLO6XYUQ2GX+q+T9A==",
           "optional": true,
           "requires": {
             "config-chain": "^1.1.13",
@@ -6290,18 +6300,18 @@
           }
         },
         "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "optional": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
         "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
         },
         "neo-async": {
           "version": "2.6.2",
@@ -6369,9 +6379,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "uglify-js": {
-          "version": "3.17.1",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.1.tgz",
-          "integrity": "sha512-+juFBsLLw7AqMaqJ0GFvlsGZwdQfI2ooKQB39PSBgMnMakcFosi9O8jCwE+2/2nMNcc0z63r9mwjoDG8zr+q0Q==",
+          "version": "3.17.4",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+          "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
           "optional": true
         },
         "wordwrap": {
@@ -6929,9 +6939,9 @@
           }
         },
         "is-core-module": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-          "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+          "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
           "dev": true,
           "requires": {
             "has": "^1.0.3"
@@ -7558,9 +7568,9 @@
           "dev": true
         },
         "object-inspect": {
-          "version": "1.12.2",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
           "dev": true
         },
         "once": {
@@ -7779,9 +7789,9 @@
           "dev": true
         },
         "is-core-module": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-          "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+          "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
           "dev": true,
           "requires": {
             "has": "^1.0.3"
@@ -8015,9 +8025,9 @@
       }
     },
     "minisearch": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-5.0.0.tgz",
-      "integrity": "sha512-VEwBhl8aFtc2UG2XmP7a4XaZxVfNhe7GvB2W/ZRGbLL3P3LbBhkoOezBWsMqG8Mr5VonqXAMRWth79XXKja1bQ=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.0.0.tgz",
+      "integrity": "sha512-N7yUgtH5T9iQfdmzI8Dnke8TK+grccrWUsdiwvalGv04hJggOUI/EpWIEQj3v8t7XSi/kSfQ7GdLAS540+GxpQ=="
     },
     "mkdirp": {
       "version": "0.5.6",
@@ -8028,9 +8038,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
         }
       }
     },
@@ -8094,9 +8104,9 @@
           }
         },
         "anymatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+          "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
           "dev": true,
           "requires": {
             "normalize-path": "^3.0.0",
@@ -8760,9 +8770,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+      "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -8850,9 +8860,9 @@
           "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
         },
         "aws4": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-          "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
@@ -9039,9 +9049,9 @@
           "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
         },
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
+          "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw=="
         },
         "qs": {
           "version": "6.5.3",
@@ -9219,9 +9229,9 @@
           "dev": true
         },
         "cookiejar": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-          "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+          "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
           "dev": true
         },
         "core-util-is": {
@@ -9346,9 +9356,9 @@
           "dev": true
         },
         "object-inspect": {
-          "version": "1.12.2",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
           "dev": true
         },
         "process-nextick-args": {
@@ -9434,9 +9444,9 @@
       }
     },
     "wiki-client": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/wiki-client/-/wiki-client-0.24.0.tgz",
-      "integrity": "sha512-1lpoCiZznOWwPbVZ4JjTMPerXGRVpRCssr9l1TorEmTWyZ2ov+0xCdZzzR3KgPXMu/YwEPxebKvGUZjlTCTYkA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/wiki-client/-/wiki-client-0.24.2.tgz",
+      "integrity": "sha512-b2vB9w6beCMg1qcNB/qtNPd8xD8K7aNqFc61vMSsEXozsKnIjMo3pQRga5aPeupSQSFQGBgVZTLhzigjVtTuIQ==",
       "dev": true,
       "requires": {
         "async": "^3.2.1",
@@ -9499,9 +9509,9 @@
           "dev": true
         },
         "camelize": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-          "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+          "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
           "dev": true
         },
         "dom-walk": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "glob": "^7.1.4",
     "lodash": "^4.17.19",
     "method-override": "^2.3.10",
-    "minisearch": "^5.0.0",
+    "minisearch": "^6.0.0",
     "mkdirp": "^0.5.5",
     "morgan": "^1.9.1",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
This, together with fedwiki/wiki-client#300, fix a problem with the site-index getting corrupted. Caused by not providing the correct original text when removing an old version of a page from the index while forking that page.

[MiniSearch v6](https://github.com/lucaong/minisearch/blob/master/CHANGELOG.md#v600), adds the ability to remove (discard) a page from the index without needing the original text.

This PR makes use of MiniSearch `discard()` and `replace()`, removing the need to have the original indexed text to be able to remove, and then re-add, pages from the index.

An issue with removing HTML tags while extracting the text from the page has also been fixed.

