### PR TITLE
Fix: remove title from call to searchPageRemove()

### DIFF
--- a/lib/search.coffee
+++ b/lib/search.coffee
@@ -131,7 +131,7 @@ module.exports = exports = (argv) ->
           )
         when "remove"
           itself.start()
-          searchPageRemove(item.slug, item.title, (e) ->
+          searchPageRemove(item.slug, (e) ->
             process.nextTick( ->
               serial(queue.shift())
             )


### PR DESCRIPTION
In #174 when removing parameters that were no longer required I miss removing title from call to `searchPageRemove()`. It was removed from the function definition, which results in a server crash when deleting a wiki page.