### PR TITLE
Use dynamic import expression to load plugin code

### DIFF
--- a/lib/plugins.coffee
+++ b/lib/plugins.coffee
@@ -29,11 +29,12 @@ module.exports = exports = (argv) ->
 		fs.exists server, (exists) ->
 			if exists
 				console.log 'starting plugin', plugin
-				try
-					plugins[plugin] = require server
+				import(server).then((exported) ->
+					plugins[plugin] = exported
 					plugins[plugin].startServer?(params)
-				catch e
+				).catch((e) ->
 					console.log 'failed to start plugin', plugin, e?.stack or e
+				)
 
 	startServers = (params) ->
 		# emitter = new events.EventEmitter()


### PR DESCRIPTION
This lets plugins choose whether to be es modules or not at the package level.

Shockingly easy server change to allow es modules in server side plugin code. Import expressions have been available and stable in node since at least v12, but this won't work in very old versions. By default this will still load server side plugins as common js modules because it hard codes the `.js` file extension, to switch a plugin to esmodules add `"type": "module"` to the top level of its package.json

Related to, but not dependent on https://github.com/fedwiki/wiki-client/pull/320