### PR TITLE
Feat: color coding per site in request logger

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -163,15 +163,15 @@ module.exports = exports = (argv) ->
     .catch (err) ->
       console.error('Unable to fetch remote resource', remote, slug, err)
       cb(err, 'Page not found', 404)
-    
 
-      
+
+
   #### Express configuration ####
   # Set up all the standard express server options,
   # including hbs to use handlebars/mustache templates
   # saved with a .html extension, and no layout.
 
-  # 
+  #
   staticPathOptions = {
     dotfiles: 'ignore'
     etag: true
@@ -558,7 +558,7 @@ module.exports = exports = (argv) ->
             dict
           , {}))
       )
-  
+
   admin = (req, res, next) ->
     if securityhandler.isAdmin(req)
       next()
@@ -603,7 +603,7 @@ module.exports = exports = (argv) ->
           res.status(fetchRes.status).end()
       .catch (err) ->
         console.log("ERROR: Proxy Request ", requestURL, err)
-        res.status(500).end()  
+        res.status(500).end()
     else
       res.status(400).end()
 
@@ -680,7 +680,7 @@ module.exports = exports = (argv) ->
     # otherwise ask pagehandler for it.
     if action.fork
       pagehandler.saveToRecycler req.params[0], (err) ->
-        if err and err isnt 'page does not exist' 
+        if err and err isnt 'page does not exist'
           console.log "Error saving #{req.params[0]} before fork: #{err}"
         if action.forkPage
           forkPageCopy = JSON.parse(JSON.stringify(action.forkPage))

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -186,10 +186,24 @@ module.exports = exports = (argv) ->
   app.engine('html', hbs.express4())
   app.set('view options', layout: false)
 
-    # use logger, at least in development, probably needs a param to configure (or turn off).
-    # use stream to direct to somewhere other than stdout.
+  # return deterministically colored strings
+  colorString = (str) ->
+    colorReset = '\x1b[0m'
+    hash = 0;
+    str.split('').forEach (char) ->
+      hash = char.charCodeAt(0) + ((hash << 5) - hash)
+    color = '\x1b[38;2'
+    for i in [0..2]
+      do (i) ->
+        value = (hash >> (i * 8)) & 0xff
+        color += ';' + value.toString()
+    color += 'm'
+    return color + str + colorReset
+
+  # use logger, at least in development, probably needs a param to configure (or turn off).
+  # use stream to direct to somewhere other than stdout.
   logger.token('vhost', (req, res) ->
-    return req.hostname)
+    return colorString(req.hostname))
   app.use(logger(':vhost :method :url :status :res[content-length] - :response-time ms'))
   app.use(cookieParser())
   app.use(bodyParser.json({ limit: argv.uploadLimit}))


### PR DESCRIPTION
This is the first half of the implementation of #190 proposed by Ward.

This mingles three StackOverflow answers and converts them to CoffeeScript.

- [How to change node.js's console font color? - Stack Overflow](https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color)
- [Create a hexadecimal colour based on a string with JavaScript - Stack Overflow](https://stackoverflow.com/questions/3426404/create-a-hexadecimal-colour-based-on-a-string-with-javascript)
- [terminal - List of ANSI color escape sequences - Stack Overflow](https://stackoverflow.com/questions/4842424/list-of-ansi-color-escape-sequences)

It will colour requests in regular and in farm mode. Both escape the hostname. Eventually we will want to consider removing the `:vhost` token from the logger in regular single-site wikis.

addresses #190