### PR TITLE
Fix Test Script

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -76,19 +76,22 @@ export default argv => {
   // create a list of plugin pages.
   const pluginPages = new Map()
 
-  Object.keys(packageJson.dependencies)
-    .filter(depend => depend.startsWith('wiki-plugin'))
-    .forEach(plugin => {
-      const pagesPath = path.join(path.dirname(require.resolve(`${plugin}/package`)), 'pages')
-      fs.readdir(pagesPath, { withFileTypes: true }, (err, entries) => {
-        if (err) return
-        entries.forEach(entry => {
-          if (entry.isFile() && !pluginPages.has(entry.name)) {
-            pluginPages.set(entry.name, { pluginName: plugin, pluginPath: entry.parentPath })
-          }
-        })
+  const dependencyPlugins = Object.keys(packageJson.dependencies).filter(depend => depend.startsWith('wiki-plugin'))
+  const plugins = dependencyPlugins.length
+    ? dependencyPlugins
+    : Object.keys(packageJson.devDependencies).filter(depend => depend.startsWith('wiki-plugin'))
+
+  plugins.forEach(plugin => {
+    const pagesPath = path.join(path.dirname(require.resolve(`${plugin}/package`)), 'pages')
+    fs.readdir(pagesPath, { withFileTypes: true }, (err, entries) => {
+      if (err) return
+      entries.forEach(entry => {
+        if (entry.isFile() && !pluginPages.has(entry.name)) {
+          pluginPages.set(entry.name, { pluginName: plugin, pluginPath: entry.parentPath })
+        }
       })
     })
+  })
 
   // #### Private utility methods. ####
   const load_parse = (loc, cb, annotations = {}) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -449,12 +449,17 @@ export default async argv => {
       })
     }
 
+    // in test (wiki-server) the plugins are listed as devDependencues, so we need to fallback to
+    // using devDEpendencies when there are no plugins in dependencies.
+    const dependencyPlugins = Object.keys(packageJson.dependencies).filter(depend => depend.startsWith('wiki-plugin'))
+    const plugins = dependencyPlugins.length
+      ? dependencyPlugins
+      : Object.keys(packageJson.devDependencies).filter(depend => depend.startsWith('wiki-plugin'))
+
     Promise.all(
-      Object.keys(packageJson.dependencies)
-        .filter(depend => depend.startsWith('wiki-plugin'))
-        .map(plugin => {
-          return getPackageFactory(plugin)
-        }),
+      plugins.map(plugin => {
+        return getPackageFactory(plugin)
+      }),
     ).then(() => res.end(JSON.stringify(factories)))
   })
 
@@ -643,6 +648,10 @@ export default async argv => {
     } catch (e) {
       return res.e(e)
     }
+    // Object.keys(packageJson.dependencies)
+    //   .filter(depend => depend.startsWith('wiki-plugin'))
+    //   .map(name => name.slice(12))
+    //   .then(names => res.send(names))
   })
   //{
   const sitemapLoc = path.join(argv.status, 'sitemap.json')

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -233,7 +233,7 @@ export default argv => {
     itself.emit('finished')
   }
   itself.isWorking = () => {
-    working
+    return working
   }
 
   itself.createSitemap = pagehandler => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "body-parser": "^2.2.1",
         "client-sessions": "^0.8.0",
-        "coffeescript": "^2.5.0",
         "cookie-parser": "^1.4.4",
         "dompurify": "^3.3.0",
         "errorhandler": "^1.5.1",
@@ -594,19 +593,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/coffeescript": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
-      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==",
-      "license": "MIT",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cookie-parser": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   "scripts": {
     "prettier:format": "prettier --write './**/*.js'",
     "prettier:check": "prettier --check ./**/*.js",
-    "test": "cd test; node --test",
-    "watch": "cd test; node --test --watch",
+    "test": "node --test",
+    "watch": "node --test --watch",
     "update-authors": "node scripts/update-authors.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "body-parser": "^2.2.1",
     "client-sessions": "^0.8.0",
-    "coffeescript": "^2.5.0",
     "cookie-parser": "^1.4.4",
     "dompurify": "^3.3.0",
     "errorhandler": "^1.5.1",


### PR DESCRIPTION
Thanks to Brian for spotting that the npm scripts for running the test would never run. These changes fixes that, and resolves issues with failing tests.

N.B. Luckily those things that were not working were due to differences in location of components between running tests here and running from within the ‘wiki’ package.

## Changes

- Corrected test script to work from root directory
- Fixed `isWorking` method in sitemap to return correctly
- Removed CoffeeScript dependency
- Enhanced plugin loading to support devDependencies
- Improved plugin page discovery with devDependencies fallback