### PR TITLE
fix(plugins): plugin detection in system plugins endpoint

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -640,10 +640,13 @@ export default async argv => {
 
   // Returns a list of installed plugins. (does this get called anymore!)
   app.get('/system/plugins.json', cors, (req, res) => {
+    // create a list of plugin pages.
     try {
-      const pluginNames = Object.keys(require.main.require('./package').dependencies)
-        .filter(depend => depend.startsWith('wiki-plugin'))
-        .map(name => name.slice(12))
+      const dependencyPlugins = Object.keys(packageJson.dependencies).filter(depend => depend.startsWith('wiki-plugin'))
+      const plugins = dependencyPlugins.length
+        ? dependencyPlugins
+        : Object.keys(packageJson.devDependencies).filter(depend => depend.startsWith('wiki-plugin'))
+      const pluginNames = plugins.map(name => name.slice(12))
       res.send(pluginNames)
     } catch (e) {
       return res.e(e)

--- a/test/server.js
+++ b/test/server.js
@@ -237,6 +237,18 @@ describe('server', () => {
       })
   })
 
+  it('should return a list of plugins', async () => {
+    await request
+      .get('/system/plugins.json')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .then(res => {
+        assert.equal(res.body.length, 2)
+        assert(res.body.includes('activity'))
+        assert(res.body.includes('video'))
+      })
+  })
+
   // Should be a version test, but doesn't seem it's supported in test mode yet.
   it.skip('server should return a version', async () => {
     await request


### PR DESCRIPTION
A fix for #205
Fix plugin discovery by checking both dependencies and
devDependencies for wiki-plugin packages. This ensures more
comprehensive plugin detection, in development
environments where plugins are listed as devDependencies.