### PR TITLE
Resolve wiki packages from argv.packageDir for local development on wiki-server

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -25,9 +25,6 @@ import path from 'node:path'
 import url from 'node:url'
 import events from 'node:events'
 
-import { createRequire } from 'node:module'
-const require = createRequire(import.meta.url)
-
 // Use dynamic import to load package.json from the main application's working directory
 const wikiPackageImport = async () => {
   let done = false
@@ -82,7 +79,7 @@ export default argv => {
     : Object.keys(packageJson.devDependencies).filter(depend => depend.startsWith('wiki-plugin'))
 
   plugins.forEach(plugin => {
-    const pagesPath = path.join(path.dirname(require.resolve(`${plugin}/package`)), 'pages')
+    const pagesPath = path.join(argv.packageDir, plugin, 'pages')
     fs.readdir(pagesPath, { withFileTypes: true }, (err, entries) => {
       if (err) return
       entries.forEach(entry => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -55,8 +55,8 @@ import pluginsFactory from './plugins.js'
 import sitemapFactory from './sitemap.js'
 import searchFactory from './search.js'
 import { warn } from 'node:console'
-import { createRequire } from 'module'
-const require = createRequire(import.meta.url)
+
+const packageSpecifier = (argv, packageName, subpath) => packageName.startsWith('.') ? packageName : url.pathToFileURL(path.join(argv.packageDir, packageName, subpath)).href
 
 // Use import to load package.json from the main application's working directory
 //const { default: packageJson } = await import('wiki/package.json', { with: { type: 'json' } })
@@ -173,7 +173,7 @@ export default async argv => {
 
   // Dynamically import security adapter (also dynamic)
   console.log('security_type', argv.security_type)
-  const securityModule = await import(argv.security_type)
+  const securityModule = await import(packageSpecifier(argv, argv.security_type, 'index.js'))
   app.securityhandler = securityhandler = securityModule.default(log, loga, argv)
 
   // If the site is owned, owner will contain the name of the owner
@@ -233,7 +233,7 @@ export default async argv => {
     maxAge: '1h',
   }
 
-  const viewsPath = path.join(require.resolve('wiki-client/package.json'), '..', 'views')
+  const viewsPath = path.join(argv.packageDir, 'wiki-client', 'views')
   app.set('views', viewsPath)
 
   app.engine(
@@ -329,7 +329,7 @@ export default async argv => {
   Object.keys(packageJson.dependencies)
     .filter(depend => depend.startsWith('wiki-plugin'))
     .forEach(plugin => {
-      const clientPath = path.join(path.dirname(require.resolve(`${plugin}/package`)), 'client')
+      const clientPath = path.join(argv.packageDir, plugin, 'client')
       const pluginPath = '/plugins/' + plugin.slice(12)
       app.use(pluginPath, cors, express.static(clientPath, staticPathOptions))
     })
@@ -447,7 +447,7 @@ export default async argv => {
 
     const getPackageFactory = plugin => {
       return new Promise(resolve => {
-        import(`${plugin}/factory.json`, { with: { type: 'json' } })
+        import(packageSpecifier(argv, plugin, 'factory.json'), { with: { type: 'json' } })
           .then(({ default: factory }) => {
             resolve(factories.push(factory))
           })
@@ -761,7 +761,7 @@ export default async argv => {
       return new Promise(resolve => {
         try {
           // Use import to load package.json from the main application's working directory
-          import(`${packageName}/package.json`, { with: { type: 'json' } }).then(({ default: packageJson }) => {
+          import(packageSpecifier(argv, packageName, 'package.json'), { with: { type: 'json' } }).then(({ default: packageJson }) => {
             resolve({ [packageName]: packageJson.version })
           })
         } catch (error) {


### PR DESCRIPTION
I needed these changes for local development on on wiki-server to work for me when I put `"wiki-server": "../wiki-server"` into my package.json on the upper `wiki` module.

plugins.js already loads server-side plugins from argv.packageDir. Several other paths still used require.resolve() or bare module specifiers (wiki-client/views, wiki-plugin-*/client, factory.json, security modules), which always follow node_modules.

Linking "wiki-client": "../wiki-client" in wiki/package.json covers client JS and views for that one package. It does not cover plugins, security, or default plugin pages — and you would need a ../ link for every package you are actively editing.

This change makes those remaining paths use packageDir, matching the convention already used elsewhere. No change to production installs where packages live under node_modules and packageDir resolves to the same tree.