### PR TITLE
sanitize wiki names in lineup up

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -377,6 +377,7 @@ export default async argv => {
       .split('/')
       .slice(1)
       .filter((_, index) => index % 2 === 0)
+      .map(u => (u.endsWith(':') ? u.slice(0, -1) : u))
     if (['plugin', 'auth'].indexOf(urlLocs[0]) > -1) {
       return next()
     }


### PR DESCRIPTION
Remove any trailing `:` which create an alias pointing the wiki without the `:`

When adding a `:` to the name of a wiki in the line-up the browser quietly add the default port, but the wiki-client will see it as a wiki with a name ending with a `:`. 

This becomes a problem when pages are forked, or items dragged of pages, in that wiki. The journal entry for these events will get marked with the site ending with `:`. 

If the wiki without the trailing `:` is also the neighbourhood all pages from one with be marked as having an identical twin from the other.

Federation search will also see it as a separate wiki, and report it as such in recent changes. In the roster plugin, when displaying the recent activity roster, `ROSTER query.search.federatedwiki.org/recent-activity`, these are see as roster categories not wiki sites.
<img width="354" height="77" alt="Screenshot 2026-06-24 at 18 18 31" src="https://github.com/user-attachments/assets/c57056ed-4e3f-4534-8369-c0d7ba28ee53" />

By removing the trailing `:` this source that can introduce this problem.

It does not address correction of any entries that have been added to a page's journal. This will be addressed in an upcoming version of the journalmatic plugin.