### PR TITLE
Allow opt-in anonymous /proxy for HTTP-only federation

### DIFF
--- a/lib/defaultargs.js
+++ b/lib/defaultargs.js
@@ -66,6 +66,7 @@ export default argv => {
     argv.security_type = 'wiki-security-' + argv.security_type
   }
   argv.security_legacy ||= false
+  argv.public_proxy ||= false
 
   // resolve all relative paths
   argv.root = path.resolve(argv.root)

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,6 +23,7 @@ import fs from 'fs'
 import path from 'path'
 import url from 'url'
 import { pipeline } from 'node:stream/promises'
+import dns from 'node:dns/promises'
 
 // From npm
 import express from 'express'
@@ -36,6 +37,16 @@ const window = new JSDOM('').window
 const DOMPurify = createDOMPurify(window)
 
 // Using native fetch API (available in Node.js 18+)
+
+// Loopback, RFC1918, link-local IPv4; loopback/link-local/ULA IPv6.
+const isPrivateIP = addr => {
+  if (addr.includes(':')) return addr === '::1' || addr.startsWith('fe80:') || addr.startsWith('fc') || addr.startsWith('fd')
+  const [a, b, c, d] = addr.split('.').map(Number)
+  return (
+    [a, b, c, d].every(n => n >= 0 && n <= 255) &&
+    (a === 10 || a === 127 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31) || (a === 169 && b === 254))
+  )
+}
 
 // Express 4 middleware
 import logger from 'morgan'
@@ -810,11 +821,30 @@ export default async argv => {
 
   // ##### Proxy routes #####
 
-  app.get('/proxy/*splat', authorized, (req, res) => {
+  app.get('/proxy/*splat', async (req, res) => {
+    const signedIn = securityhandler.isAuthorized(req)
+    if (!signedIn && !argv.public_proxy) return res.sendStatus(403)
     const pathParts = req.originalUrl.split('/')
     const remoteHost = pathParts[2]
     pathParts.splice(0, 3)
     const remoteResource = pathParts.join('/')
+    // Anonymous: refuse hosts that are or resolve to private IPs (owners unchanged).
+    if (!signedIn) {
+      let host = remoteHost.toLowerCase()
+      if (host.startsWith('[')) {
+        const end = host.indexOf(']')
+        if (end < 0) return res.sendStatus(403)
+        host = host.slice(1, end)
+      } else {
+        host = host.split(':')[0]
+      }
+      try {
+        const { address } = await dns.lookup(host)
+        if (isPrivateIP(address.toLowerCase())) return res.sendStatus(403)
+      } catch {
+        return res.sendStatus(403)
+      }
+    }
     // this will fail if remote is TLS only!
     const requestURL = 'http://' + remoteHost + '/' + remoteResource
     console.log('PROXY Request: ', requestURL)
@@ -824,7 +854,8 @@ export default async argv => {
       requestURL.endsWith('.jpg') ||
       pathParts[0] === 'plugin'
     ) {
-      fetch(requestURL, { signal: AbortSignal.timeout(2000) })
+      // Anonymous: do not follow redirects (could land on a private IP).
+      fetch(requestURL, { signal: AbortSignal.timeout(2000), redirect: signedIn ? 'follow' : 'error' })
         .then(async fetchRes => {
           if (fetchRes.ok) {
             res.set('content-type', fetchRes.headers.get('content-type'))


### PR DESCRIPTION
## Summary

- Adds an opt-in `public_proxy` config flag (default `false`) so anonymous visitors on an HTTPS wiki can use `/proxy` to fetch HTTP-only remote pages. (Like much of the resources in how-to-wiki for example)
- Signed-in owners keep the previous `/proxy` behavior, including localhost and LAN targets.
- Anonymous `/proxy` requests that target (or resolve to) localhost or private/link-local addresses are rejected; redirects are not followed for those callers.

## Why this is useful

Many default and how-to-wiki resources in the federation still live on HTTP-only sites. When a reader is on HTTPS, the browser blocks those fetches as mixed content. The existing `/proxy` route already solves that for **signed-in** owners, but ordinary visitors hit 403, so linked how-to-wiki pages and similar neighbor content look broken.

With `public_proxy: true`, a farm can make that mixed-content bridge available to everyone without changing the client.

## Safety (opt-in, not an open proxy)

This is **not** a general open proxy:

- **Opt-in only** — default remains login-gated; nothing changes until `public_proxy` is set.
- **GET only** — same as today.
- **Narrow path types** — still limited to `.json`, `.png`, `.jpg`, and `plugin/...` (wiki-shaped resources, not arbitrary URLs).
- **HTTP-only upstream** — still forces `http://` to the remote host.
- **Short timeout** — existing 2s abort remains.
- **Anonymous SSRF guard** — for anonymous callers, the host is DNS-resolved and private/loopback/link-local addresses are refused; redirects are not followed. That restriction does not apply to signed-in owners, so existing local/LAN federation is unchanged.

Enable with: `{ "public_proxy": true }` in the wiki config.

You can test this change out with the public proxy turned on here:
https://public-proxy.aolc.cc/view/welcome-visitors/view/how-to-wiki/fed.wiki.org/field-guide-to-the-federation

## Test plan

- [ ] With default config (no `public_proxy`): anonymous `/proxy/...` still returns 403; signed-in owner still works as before (including localhost if used).
- [ ] With `public_proxy: true`: anonymous fetch of a public HTTP wiki page JSON via `/proxy/{host}/{slug}.json` succeeds.
- [ ] With `public_proxy: true`: anonymous `/proxy/127.0.0.1/...` and `/proxy/localhost/...` return 403.
- [ ] With `public_proxy: true`: a hostname that resolves to a private IP is rejected (403).
- [ ] With `public_proxy: true`: anonymous requests do not follow redirects to another host.
- [ ] HTTPS client can resolve an HTTP-only neighbor through `/proxy` without signing in.
